### PR TITLE
Update crawler to cache web request form github.

### DIFF
--- a/internal/search/crawler/github/queries.go
+++ b/internal/search/crawler/github/queries.go
@@ -99,16 +99,12 @@ func Path(p string) queryField {
 // determine the date of a file.
 type RequestConfig struct {
 	perPage     uint64
-	retryCount  uint64
 	accessToken string
 }
 
-func NewRequestConfig(
-	perPage, retryCount uint64, accessToken string) RequestConfig {
-
+func NewRequestConfig(perPage uint64, accessToken string) RequestConfig {
 	return RequestConfig{
 		perPage:     perPage,
-		retryCount:  retryCount,
 		accessToken: accessToken,
 	}
 }
@@ -136,12 +132,6 @@ func (rc RequestConfig) ContentsRequest(fullRepoName, path string) string {
 func (rc RequestConfig) CommitsRequest(fullRepoName, path string) string {
 	uri := fmt.Sprintf("repos/%s/commits", fullRepoName)
 	return rc.makeRequest(uri, Query{Path(path)}).URL()
-}
-
-// How many times to retry the queries before giving up (used by the crawler,
-// not Github).
-func (rc RequestConfig) RetryCount() uint64 {
-	return rc.retryCount
 }
 
 func (rc RequestConfig) makeRequest(path string, query Query) request {

--- a/internal/search/go.mod
+++ b/internal/search/go.mod
@@ -3,6 +3,8 @@ module sigs.k8s.io/kustomize/internal/search
 go 1.12
 
 require (
+	github.com/gomodule/redigo v2.0.0+incompatible
+	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/internal/search/go.sum
+++ b/internal/search/go.sum
@@ -1,3 +1,7 @@
+github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
+github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
+github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/internal/search/httpclient/httpclient.go
+++ b/internal/search/httpclient/httpclient.go
@@ -1,0 +1,19 @@
+package httpclient
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gomodule/redigo/redis"
+	"github.com/gregjones/httpcache"
+	redis_cache "github.com/gregjones/httpcache/redis"
+)
+
+func NewClient(conn redis.Conn) *http.Client {
+	etagCache := redis_cache.NewWithClient(conn)
+	tr := httpcache.NewTransport(etagCache)
+	return &http.Client{
+		Transport: tr,
+		Timeout:   10 * time.Second,
+	}
+}


### PR DESCRIPTION
- Increase logging signal to noise ratio.
- Allow to specify the `http.Client` for github requests. (This allows
 the use of caching http.Clients).
- Clean up implementation.